### PR TITLE
[WIP] Fix blurry textures for Chrome and other browsers

### DIFF
--- a/app/js/components/item-preview.js
+++ b/app/js/components/item-preview.js
@@ -82,7 +82,7 @@ Vue.component("item-preview-inventoryimage", {
 		}
 	},
 	template: /*html*/`
-		<img :src="imgsrc" :width="size" :height="size" style="image-rendering: crisp-edges;"/>
+		<img :src="imgsrc" :width="size" :height="size" style="image-rendering: crisp-edges; image-rendering: pixelated; image-rendering: -moz-crisp-edges;"/>
   `
 });
 
@@ -95,7 +95,7 @@ Vue.component("cube-face", {
 				width: this.size + "px",
 				height: this.size + "px",
 				"backface-visibility": "hidden",
-				"image-rendering": ["crisp-edges", "-webkit-optimize-contrast", "pixelated"],
+				"image-rendering": ["crisp-edges", "-webkit-optimize-contrast", "pixelated", "-moz-crisp-edges"],
 				"background-size": "cover",
 				"transform": `rotateX(${this.rotateX}) rotateY(${this.rotateY}) translateZ(${this.translateZ})`,
 				"background-image": `url(${this.img})`


### PR DESCRIPTION
dd1638d doesn't fix it for Chrome.

> Chrome only supports `pixelated` and Firefox only supports `crisp-edges`, and for the deepest browser support, you gotta prefix it to `-moz-crisp-edges`. Fortunately, you can smash them all together and it seems fine.
https://css-tricks.com/keep-pixelated-images-pixelated-as-they-scale/

(`-moz-crisp-edges` might not be needed, but it also doesn't hurt anything)