### PR TITLE
Resursive texture export

### DIFF
--- a/textures.lua
+++ b/textures.lua
@@ -1,20 +1,33 @@
 local count = 0
 local size = 0
 
+function mtinfo.copy_texture_dir(src, target)
+	minetest.mkdir(target)
+
+	local file_list = minetest.get_dir_list(src, false)
+	for _, filename in pairs(file_list) do
+		count = count+1
+		size = size + mtinfo.copyfile(src .. "/" .. filename, target .. "/" .. filename)
+	end
+
+	local dir_list = minetest.get_dir_list(src, true)
+	for _, subdir in pairs(dir_list) do
+		minetest.mkdir(target .. "/" .. subdir)
+		mtinfo.copy_texture_dir(src .. "/" .. subdir, target .. "/" .. subdir)
+	end
+end
+
 function mtinfo.export_textures()
 	for _, modname in ipairs(minetest.get_modnames()) do
-	  local modpath = minetest.get_modpath(modname)
-	  local destination_path = mtinfo.basepath .. "/textures"
-	  minetest.mkdir(destination_path)
+		local modpath = minetest.get_modpath(modname)
+		local destination_path = mtinfo.basepath .. "/textures"
+		minetest.mkdir(destination_path)
 
-	  if modpath then
-	    local texturepath = modpath .. "/textures"
-	    local dir_list = minetest.get_dir_list(texturepath)
-	    for _, filename in pairs(dir_list) do
-	      count = count + 1
-	      size = size + mtinfo.copyfile(texturepath .. "/" .. filename, destination_path .. "/" .. filename)
-	    end
-	  end
+		if modpath then
+			local source_path = modpath .. "/textures"
+			print("[mtinfo] exporting " .. source_path .. " into " .. destination_path)
+			mtinfo.copy_texture_dir(source_path, destination_path)
+		end
 	end
 	print("[mtinfo] exported " .. count .. " textures (" .. size .. " bytes)")
 	local data = {

--- a/textures.lua
+++ b/textures.lua
@@ -13,7 +13,8 @@ function mtinfo.copy_texture_dir(src, target)
 	local dir_list = minetest.get_dir_list(src, true)
 	for _, subdir in pairs(dir_list) do
 		minetest.mkdir(target .. "/" .. subdir)
-		mtinfo.copy_texture_dir(src .. "/" .. subdir, target .. "/" .. subdir)
+		-- Merge src subdir into target
+		mtinfo.copy_texture_dir(src .. "/" .. subdir, target)
 	end
 end
 


### PR DESCRIPTION
Textures from mods like Draconis where not being properly copied. I would also add a feature like skip the copy of non-texture files that mods may eventually put under textures/ folder.